### PR TITLE
add: table hover interactions, cell permalink with persistent selection

### DIFF
--- a/.opencode/skill/documentation-cell-permalink/SKILL.md
+++ b/.opencode/skill/documentation-cell-permalink/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: documentation-cell-permalink
+description: Cell permalink button and hash-based highlight restore for the comparison table
+---
+
+# Cell Permalink
+
+## Business Goal
+
+Let users share a direct link to a specific cell in the comparison table. When someone receives the link, the page scrolls to and highlights that exact agent+feature combination, making it easy to point others to a particular data point during discussions or reviews.
+
+## Features
+
+### Permalink Button
+
+When the user hovers over any agent body cell (not the feature-name column), a small "#" button appears in the top-right corner of the cell. The button is subtle (semi-transparent) and becomes fully opaque on hover to avoid visual clutter.
+
+### Clipboard Copy and Persistent Selection
+
+Clicking the "#" button copies a stable URL to the clipboard **and** activates a persistent selection on that cell. The URL contains a hash fragment that encodes the agent and feature:
+
+- Category cell: `#claude-code!planmode`
+- Subfeature cell: `#claude-code!planmode/dual-mode`
+
+The hash format is `#<agentId>!<featureSlug>` for category rows and `#<agentId>!<featureSlug>/<subfeatureSlug>` for subfeature rows. The browser URL is **not** modified when copying.
+
+If a different cell was already selected, clicking "#" on a new cell dismisses the previous selection and activates the new one.
+
+### Copy Feedback
+
+After a successful copy, the "#" button turns green with a checkmark, and a "Copied to clipboard" tooltip appears above it. Both fade out after 1.5 seconds.
+
+### Persistent Cell Selection
+
+Both the "#" button click and loading a page with a hash activate a **persistent selection** on the target cell. The selection is visible as the full cross-highlight effect (column hover, smart row highlight, cross dimming, extra background) plus an in-flow "× Remove highlight" bar at the bottom of the cell.
+
+The selection behaves as follows:
+
+- **Hovering another cell**: The selection highlight is temporarily replaced by the normal hover highlight. The "× Remove highlight" bar stays visible in the selected cell.
+- **Leaving the table**: The full selection highlight re-appears automatically.
+- **Clicking "× Remove highlight"**: The selection is fully dismissed — all highlight classes are removed, the cell DOM is restored, and the URL hash is cleaned via `history.replaceState`.
+
+### "× Remove highlight" Bar
+
+The bar is an in-flow element inside the selected cell (not an overlay). When a cell is selected:
+
+1. The cell's existing children are wrapped in a `.cell-content-wrap` div.
+2. The cell switches to `display: flex; flex-direction: column` (via `.has-selection` class) with zero padding. The wrapper inherits the original cell padding.
+3. The remove bar is appended as a second flex child, spanning the full cell width edge-to-edge.
+
+This makes the cell visually split into two areas: the content area on top and the remove bar at the bottom.
+
+### Hash-Based Highlight Restore
+
+When the page loads with a cell permalink hash:
+
+1. The target cell is found by matching `data-agent-id` and `data-feature` attributes on `<td>` elements.
+2. `selectedCellInfo` is stored (agentId, feature, colIndex) and the persistent selection is activated.
+3. The full cross-highlight effect is applied programmatically: column hover, smart row highlight (same logic as the hover system), cross dimming, an extra background on the target cell, and the "× Remove highlight" bar.
+4. The page scrolls smoothly to center the target cell in the viewport.
+
+## Data Attributes
+
+Each agent `<td>` in the table body carries two data attributes used for cell identification:
+
+- `data-agent-id` — the agent's stable ID (e.g., `"claude-code"`, `"cursor"`)
+- `data-feature` — the feature path: just the slug for category rows (e.g., `"planmode"`), or `featureSlug/subfeatureSlug` for subfeature rows (e.g., `"planmode/dual-mode"`)
+
+Agent `<th>` header cells also carry `data-agent-id` for column identification.
+
+These attributes are threaded from the data layer (`StatusFeature.tsx`, `SubscriptionsFeature.tsx`) through `agentIds` props into the Astro components (`StatusFeature.astro`, `Subfeature.astro`, `SubscriptionsFeature.astro`).
+
+## Design Decisions
+
+- **Single shared button element**: One `<button>` is created and repositioned between cells on hover, rather than inserting a button into every cell. This avoids DOM bloat across the many table cells.
+- **Single shared remove bar element**: One `<div>` is created and moved into the selected cell. Only one cell can be selected at a time.
+- **URL not modified on copy**: Clicking "#" only copies to clipboard. The browser address bar stays unchanged so users don't accumulate unwanted history entries.
+- **Persistent selection with hover coordination**: The selection highlight coexists with the hover system. On `mouseover`, the hash-specific classes (`.hash-highlight`, `.hash-row`) are temporarily cleared so the hover system can highlight the hovered cell. On `mouseleave`, the selection highlight is re-applied via `applySelectedHighlight()`. The "× Remove highlight" bar remains visible at all times (even during hover).
+- **In-flow remove bar**: The bar is part of the cell's normal document flow (not absolutely positioned). The cell uses flex-column layout (`.has-selection`) with a content wrapper (`.cell-content-wrap`) and the bar as siblings. This ensures the bar is a true part of the cell rather than an overlay.
+- **Content wrapping/unwrapping**: `wrapCellContent()` moves the cell's children into a `.cell-content-wrap` div. `unwrapCellContent()` reverses this. The wrapper excludes the remove bar and permalink button elements.
+- **Smooth scroll to center**: `scrollIntoView({ behavior: 'smooth', block: 'center' })` positions the cell in the middle of the viewport so the user sees surrounding context.
+- **Hash row class**: Since `:hover` CSS pseudo-class doesn't apply to programmatic highlights, a `.hash-row` class on the `<tr>` mirrors the `tr:hover td` background and opacity rules.
+- **Static helper functions**: `getCellStatusStatic` and `statusMatchesThresholdStatic` duplicate the hover system's logic because the originals are scoped inside `initTableHover`. This keeps the two systems decoupled.
+- **Module-level state**: `selectedCellInfo` is declared at module scope (outside both `initTableHover` and `initCellPermalink`) so both systems can read it. The hover system checks it on `mouseover`/`mouseleave`; the permalink system writes it on `#` click and hash restore.

--- a/.opencode/skill/documentation-table-hover/SKILL.md
+++ b/.opencode/skill/documentation-table-hover/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: documentation-table-hover
+description: Business purpose of the comparison table hover interactions including column highlight, smart row highlight, cross dimming, and badge contrast mode
+---
+
+# Table Hover Interactions
+
+## Business Goal
+
+Help users compare AI coding agents by making the comparison table interactive. When a user hovers over any agent cell, the table highlights relevant information and dims the rest, creating a focused comparison experience.
+
+## Features
+
+### Column Highlight
+
+When the user hovers over any cell in an agent column, the entire column gets a subtle background tint and the column header is highlighted. This helps the user track which agent they're looking at vertically.
+
+### Badge Contrast Mode
+
+Badges for "supported" and "partially-supported" statuses receive a bold colored border (green for supported, amber for partial) when they are in the hovered column or in a highlighted row cell. "Not-supported" and "not-verified" badges are intentionally left unchanged — the contrast draws attention to positive statuses.
+
+### Smart Row Highlight (Borders Only)
+
+When hovering a cell, the row highlight logic selectively applies badge contrast borders based on the hovered badge's status:
+
+- Hovering "supported" → only other "supported" badges in the row get contrast borders
+- Hovering "no", "partial", or "not verified" → both "partially-supported" and "supported" badges get contrast borders
+
+This lets the user instantly see which other agents do the same or better for that feature. The row background always highlights all cells (not selective) — only the border logic is smart.
+
+Subscription cells with links are treated as "supported" for this logic.
+
+### Cross Dimming
+
+When hovering any agent cell, all cells outside the cross (hovered row + hovered column) fade to reduced opacity. The first column (feature/subfeature names) always stays fully visible since feature context is always important. This creates a visual crosshair that focuses attention on the relevant row and column.
+
+### Coordination with Persistent Cell Selection
+
+The hover system is aware of the persistent cell selection state (managed by the cell-permalink system via `selectedCellInfo`). When a cell is selected (via "#" click or page load with hash):
+
+- **On `mouseover`**: The hover system calls `clearSelectedHighlight()` to temporarily remove the hash-specific visual classes (`.hash-highlight`, `.hash-row`), then applies its own hover highlight as normal. The "× Remove highlight" bar in the selected cell stays visible.
+- **On `mouseleave`**: After clearing hover classes, the hover system calls `applySelectedHighlight()` to re-apply the full selection highlight (column hover, row highlight, cross-active, hash-highlight, hash-row, and the remove bar).
+
+This means the hover system always takes priority while the user is hovering, and the selection automatically restores when the mouse leaves.
+
+## Design Decisions
+
+- **Background is always full-row**: The background tint applies to every cell in the hovered row, not just the smart-selected ones. Only borders are selective. This avoids a jarring "holes in the row" effect.
+- **First column never dims**: Feature and subfeature names are always readable regardless of hover state.
+- **Transparent border by default**: All badges have a 2px transparent border to prevent layout shift when the visible border appears on hover.
+- **Subscription cells as "supported"**: Cells with subscription links (no badge) are treated as "supported" for the smart highlight logic since having links means the agent supports subscriptions.
+- **Selection-aware cleanup**: The `mouseleave` handler checks `selectedCellInfo` before deciding whether to leave the table in a neutral state (no selection) or re-apply the selection highlight.

--- a/.opencode/skill/documentation/SKILL.md
+++ b/.opencode/skill/documentation/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: documentation
+description: Describes different areas of the code and how business-purpose documentation is embedded via DOCUMENTATION-SKILL tags
+---
+
+# Documentation System
+
+## How It Works
+
+Business-purpose documentation is stored in dedicated skills and linked to code regions using tagged comments.
+
+When you encounter a comment like:
+
+```css
+/* <DOCUMENTATION-SKILL:some-tag> */
+...code...
+/* </DOCUMENTATION-SKILL:some-tag> */
+```
+
+Extract the tag name and load the skill `documentation-<tag>` to understand the business purpose of the marked code region.
+
+## Tag Format
+
+Inside CSS blocks:
+
+```css
+/* <DOCUMENTATION-SKILL:tag> */
+/* </DOCUMENTATION-SKILL:tag> */
+```
+
+Inside JS/TS blocks:
+
+```js
+// <DOCUMENTATION-SKILL:tag>
+// </DOCUMENTATION-SKILL:tag>
+```
+
+## When to Load
+
+- When you read a file and encounter a `DOCUMENTATION-SKILL` tag, load the corresponding `documentation-<tag>` skill **before** making changes to the tagged region.
+- This ensures you understand the business purpose and constraints before modifying the code.
+
+## Known Tags
+
+| Tag              | Skill                          | Description                                                                                               |
+| ---------------- | ------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| `table-hover`    | `documentation-table-hover`    | Comparison table hover interactions: column highlight, smart row highlight, cross dimming, badge contrast |
+| `cell-permalink` | `documentation-cell-permalink` | Cell permalink button, clipboard copy, hash-based highlight restore with scroll                           |

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "prettier": "^3.7.4",
     "rehype-slug": "^6.0.0",
     "sharp": "^0.34.5",
-    "typescript": "^5.9.3",
-    "zod": "^4.2.1"
+    "typescript": "^5.9.3"
   },
   "devDependencies": {
     "vite": "^7.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
-      zod:
-        specifier: ^4.2.1
-        version: 4.2.1
     devDependencies:
       vite:
         specifier: ^7.3.0
@@ -2061,9 +2058,6 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
-  zod@4.2.1:
-    resolution: {integrity: sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -4410,7 +4404,5 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
-
-  zod@4.2.1: {}
 
   zwitch@2.0.4: {}

--- a/src/cms/features/StatusFeature/StatusFeature.astro
+++ b/src/cms/features/StatusFeature/StatusFeature.astro
@@ -11,9 +11,10 @@ interface Props {
   slug: string;
   statuses: Array<Status>;
   weight: number;
+  agentIds: string[];
 }
 
-const { name, mainColor, secondaryColor, slug, statuses, weight } = Astro.props;
+const { name, mainColor, secondaryColor, slug, statuses, weight, agentIds } = Astro.props;
 ---
 
 <tr class="category-row" style={`--main-feature-color: ${mainColor}; --secondary-feature-color: ${secondaryColor}`}>
@@ -23,9 +24,9 @@ const { name, mainColor, secondaryColor, slug, statuses, weight } = Astro.props;
       </InternalLink>
       <PointsBadge points={weight} />
     </td>
-    {statuses.map((status) => {
+    {statuses.map((status, i) => {
       return (
-        <td>
+        <td data-agent-id={agentIds[i]} data-feature={slug}>
           <FeatureCell status={status} />
         </td>
       );

--- a/src/cms/features/StatusFeature/StatusFeature.tsx
+++ b/src/cms/features/StatusFeature/StatusFeature.tsx
@@ -116,6 +116,7 @@ class ParsedStatusFeature<
           (id) => this.statusByAgentId.get(id) ?? Status.NotSupported,
         ),
         weight: this.meta.weight,
+        agentIds: sortedAgentIds,
       },
       subfeatures: this.parsedSubfeatures.map((subfeature) => ({
         Component: SubfeatureComponent,
@@ -123,12 +124,14 @@ class ParsedStatusFeature<
           mainColor: this.meta.mainColor,
           secondaryColor: this.meta.secondaryColor,
           featureLink,
+          featureSlug: this.meta.slug,
           slug: subfeature.slug,
           name: subfeature.displayName,
           statuses: sortedAgentIds.map(
             (id) => subfeature.statusByAgent.get(id) ?? Status.NotSupported,
           ),
           weight: subfeature.weight,
+          agentIds: sortedAgentIds,
         },
       })),
     };

--- a/src/cms/features/StatusFeature/Subfeature.astro
+++ b/src/cms/features/StatusFeature/Subfeature.astro
@@ -8,13 +8,15 @@ interface Props {
   mainColor: string;
   secondaryColor: string;
   featureLink: string;
+  featureSlug: string;
   slug: string;
   name: string;
   statuses: Array<Status>;
   weight: number;
+  agentIds: string[];
 }
 
-const {featureLink, name, slug, secondaryColor, mainColor, statuses, weight} = Astro.props;
+const {featureLink, featureSlug, name, slug, secondaryColor, mainColor, statuses, weight, agentIds} = Astro.props;
 ---
 
 <tr class="feature-row" style={`--main-feature-color: ${mainColor}; --secondary-feature-color: ${secondaryColor}`}>
@@ -24,9 +26,9 @@ const {featureLink, name, slug, secondaryColor, mainColor, statuses, weight} = A
     </InternalLink>
     <PointsBadge points={weight} size="small" />
   </td>
-  {statuses.map((status) => {
+  {statuses.map((status, i) => {
     return (
-      <td>
+      <td data-agent-id={agentIds[i]} data-feature={`${featureSlug}/${slug}`}>
         <FeatureCell status={status} />
       </td>
     );

--- a/src/cms/features/SubscriptionsFeature/SubscriptionsFeature.astro
+++ b/src/cms/features/SubscriptionsFeature/SubscriptionsFeature.astro
@@ -9,9 +9,10 @@ interface Props {
   secondaryColor: string;
   slug: string;
   linksByAgent: Array<SubscriptionLink[]>;
+  agentIds: string[];
 }
 
-const { name, mainColor, secondaryColor, slug, linksByAgent } = Astro.props;
+const { name, mainColor, secondaryColor, slug, linksByAgent, agentIds } = Astro.props;
 ---
 
 <tr class="category-row" style={`--main-feature-color: ${mainColor}; --secondary-feature-color: ${secondaryColor}`}>
@@ -20,9 +21,9 @@ const { name, mainColor, secondaryColor, slug, linksByAgent } = Astro.props;
         {name}
       </InternalLink>
     </td>
-    {linksByAgent.map((links) => {
+    {linksByAgent.map((links, i) => {
       return (
-        <td>
+        <td data-agent-id={agentIds[i]} data-feature={slug}>
           <FeatureCell links={links} mainColor={mainColor} />
         </td>
       );

--- a/src/cms/features/SubscriptionsFeature/SubscriptionsFeature.tsx
+++ b/src/cms/features/SubscriptionsFeature/SubscriptionsFeature.tsx
@@ -82,6 +82,7 @@ class ParsedSubscriptionsFeature implements ParsedFeature {
         linksByAgent: sortedAgentIds.map(
           (id) => this.linksByAgentId.get(id) ?? [],
         ),
+        agentIds: sortedAgentIds,
       },
     };
   }

--- a/src/components/Badge.astro
+++ b/src/components/Badge.astro
@@ -79,6 +79,10 @@ const icon = (status === Status.NotSupported)
     border-radius: 20px;
     font-size: 0.8rem;
     font-weight: 500;
+    /* <DOCUMENTATION-SKILL:table-hover> */
+    border: 2px solid transparent;
+    transition: border-color 0.15s ease;
+    /* </DOCUMENTATION-SKILL:table-hover> */
   }
 
   .badge-icon {
@@ -125,6 +129,19 @@ const icon = (status === Status.NotSupported)
   .badge.not-verified .badge-icon {
     color: var(--badge-not-verified-icon);
   }
+
+  /* <DOCUMENTATION-SKILL:table-hover> */
+  /* Column/row hover contrast mode — bold border on supported/partial badges */
+  :global(.column-hover) .badge.supported,
+  :global(.row-highlight) .badge.supported {
+    border-color: var(--badge-supported-icon);
+  }
+
+  :global(.column-hover) .badge.partially-supported,
+  :global(.row-highlight) .badge.partially-supported {
+    border-color: var(--badge-partial-icon);
+  }
+  /* </DOCUMENTATION-SKILL:table-hover> */
 
   /* Smaller badges for feature rows */
   :global(.feature-row) .badge {

--- a/src/components/ComparisonTable.astro
+++ b/src/components/ComparisonTable.astro
@@ -20,7 +20,7 @@ const { sortedAgents, features, maxScore, scoreByAgentId } = await table.getTabl
       <tr>
         <th class="feature-col">Feature</th>
         {sortedAgents.map((agent) => (
-          <th class="agent-col">
+          <th class="agent-col" data-agent-id={agent.id}>
             <span class="agent-name">{agent.name}</span>
             <ScoreBadge score={scoreByAgentId.get(agent.id)!} maxScore={maxScore} />
           </th>
@@ -105,7 +105,201 @@ const { sortedAgents, features, maxScore, scoreByAgentId } = await table.getTabl
   td {
     padding: 0.875rem 1.25rem;
     vertical-align: middle;
+    transition: opacity 0.15s ease;
   }
+
+  /* <DOCUMENTATION-SKILL:table-hover> */
+  /* Column hover — subtle highlight on header and body cells */
+  :global(th.agent-col.column-hover) {
+    background-color: rgba(0, 0, 0, 0.05);
+  }
+
+  :global(td.column-hover) {
+    background-color: rgba(0, 0, 0, 0.05);
+  }
+
+  /* Row hover — background on all cells */
+  :global(tbody tr:hover td) {
+    background-color: rgba(0, 0, 0, 0.05);
+  }
+
+  /* Cross intersection — cell in both hovered row and hovered column */
+  :global(tbody tr:hover td.column-hover) {
+    background-color: rgba(0, 0, 0, 0.09);
+  }
+
+  /* Dim cells outside the cross */
+  :global(table.cross-active tbody td) {
+    opacity: 0.4;
+  }
+
+  /* Un-dim cells in the hovered column */
+  :global(table.cross-active tbody td.column-hover) {
+    opacity: 1;
+  }
+
+  /* Un-dim cells in the hovered row */
+  :global(table.cross-active tbody tr:hover td) {
+    opacity: 1;
+  }
+
+  /* First column (feature names) always visible */
+  :global(table.cross-active tbody td:first-child) {
+    opacity: 1;
+  }
+  /* </DOCUMENTATION-SKILL:table-hover> */
+
+  /* <DOCUMENTATION-SKILL:cell-permalink> */
+  /* Agent cells need relative positioning for the permalink button */
+  :global(tbody td[data-agent-id]) {
+    position: relative;
+  }
+
+  /* Permalink '#' button — appears on cell hover */
+  :global(.cell-permalink) {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    width: 18px;
+    height: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1;
+    font-family: monospace;
+    color: var(--text-secondary);
+    background-color: var(--bg-card);
+    border: 1px solid var(--border-light);
+    border-radius: 4px;
+    cursor: pointer;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.12s ease, background-color 0.12s ease, color 0.12s ease;
+    z-index: 2;
+    text-decoration: none;
+    padding: 0;
+  }
+
+  :global(tbody td[data-agent-id]:hover .cell-permalink) {
+    opacity: 0.6;
+    pointer-events: auto;
+  }
+
+  :global(.cell-permalink:hover) {
+    opacity: 1 !important;
+    background-color: var(--text-primary);
+    color: var(--bg-card);
+  }
+
+  :global(.cell-permalink.copied) {
+    opacity: 1 !important;
+    background-color: #22c55e;
+    color: #fff;
+    border-color: #22c55e;
+  }
+
+  /* "Copied to clipboard" tooltip above the '#' button */
+  :global(.cell-permalink-tooltip) {
+    position: absolute;
+    bottom: calc(100% + 4px);
+    right: 0;
+    white-space: nowrap;
+    font-size: 11px;
+    font-weight: 500;
+    line-height: 1;
+    color: #fff;
+    background-color: #22c55e;
+    padding: 4px 8px;
+    border-radius: 4px;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    z-index: 3;
+  }
+
+  :global(.cell-permalink-tooltip.visible) {
+    opacity: 1;
+  }
+
+  /* Hash-based highlight — applied when page loads with a cell hash */
+  :global(td.hash-highlight) {
+    background-color: rgba(0, 0, 0, 0.09);
+  }
+
+  /* Hash row highlight — mirrors tr:hover behavior for programmatic highlight */
+  :global(tbody tr.hash-row td) {
+    background-color: rgba(0, 0, 0, 0.05);
+  }
+
+  :global(tbody tr.hash-row td.column-hover) {
+    background-color: rgba(0, 0, 0, 0.09);
+  }
+
+  :global(table.cross-active tbody tr.hash-row td) {
+    opacity: 1;
+  }
+
+  /* Selected cell: zero out padding and switch to flex-column.
+     The wrapper inherits the original padding, and the remove bar spans edge-to-edge. */
+  :global(td.has-selection) {
+    display: flex;
+    flex-direction: column;
+    padding: 0 !important;
+  }
+
+  /* Wrapper around the original cell content, inherits the cell's normal padding */
+  :global(.cell-content-wrap) {
+    flex: 1;
+    padding: 0.875rem 1.25rem;
+  }
+
+  /* "× Remove highlight" bar — in-flow full-width strip at bottom of selected cell */
+  :global(.remove-highlight) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 3px;
+    height: 22px;
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1;
+    color: var(--text-primary);
+    background-color: rgba(0, 0, 0, 0.13);
+    cursor: pointer;
+    transition: background-color 0.12s ease;
+  }
+
+  :global(.remove-highlight:hover) {
+    background-color: rgba(0, 0, 0, 0.2);
+  }
+
+  /* Responsive: match wrapper padding to the original cell padding at each breakpoint */
+  @media (max-width: 900px) {
+    :global(.cell-content-wrap) {
+      padding: 0.75rem 0.75rem;
+    }
+
+    :global(.category-row .cell-content-wrap) {
+      padding: 0.9rem 0.75rem;
+    }
+
+    :global(.feature-row .cell-content-wrap) {
+      padding: 0.4rem 0.75rem;
+    }
+  }
+
+  @media (max-width: 600px) {
+    :global(.category-row .cell-content-wrap) {
+      padding: 0.8rem 0.6rem;
+    }
+
+    :global(.feature-row .cell-content-wrap) {
+      padding: 0.35rem 0.6rem;
+    }
+  }
+  /* </DOCUMENTATION-SKILL:cell-permalink> */
 
   /* Responsive */
   @media (max-width: 900px) {
@@ -156,3 +350,427 @@ const { sortedAgents, features, maxScore, scoreByAgentId } = await table.getTabl
     }
   }
 </style>
+
+<script>
+  // <DOCUMENTATION-SKILL:cell-permalink>
+  // --- Persistent cell selection state (shared between hover and permalink systems) ---
+  let selectedCellInfo: {
+    agentId: string;
+    feature: string;
+    colIndex: number;
+  } | null = null;
+
+  // Shared "× Remove highlight" bar element (reused, repositioned between cells)
+  const removeBar = document.createElement('div');
+  removeBar.className = 'remove-highlight';
+  removeBar.textContent = '\u00d7 Remove highlight';
+  removeBar.setAttribute('role', 'button');
+  removeBar.setAttribute('aria-label', 'Remove cell highlight');
+
+  // Static versions of hover-logic helpers (used by selection highlight, outside initTableHover scope)
+  function getCellStatusStatic(cell: HTMLTableCellElement): string | null {
+    const badge = cell.querySelector('.badge');
+    if (badge) {
+      if (badge.classList.contains('supported')) return 'supported';
+      if (badge.classList.contains('partially-supported')) return 'partially-supported';
+      if (badge.classList.contains('not-supported')) return 'not-supported';
+      if (badge.classList.contains('not-verified')) return 'not-verified';
+    }
+    if (cell.querySelector('.links-list')) return 'supported';
+    return null;
+  }
+
+  function statusMatchesThresholdStatic(cellStatus: string | null, hoveredStatus: string): boolean {
+    if (!cellStatus) return false;
+    if (hoveredStatus === 'supported') {
+      return cellStatus === 'supported';
+    }
+    return cellStatus === 'supported' || cellStatus === 'partially-supported';
+  }
+
+  /**
+   * Wrap existing cell children in a .cell-content-wrap div so the cell
+   * can use flex-column layout with the remove bar as a second child.
+   * Skips the remove bar and permalink button if present. No-ops if already wrapped.
+   */
+  function wrapCellContent(cell: HTMLTableCellElement) {
+    if (cell.querySelector('.cell-content-wrap')) return;
+    const wrapper = document.createElement('div');
+    wrapper.className = 'cell-content-wrap';
+    // Collect children to wrap (exclude remove bar and permalink button)
+    const children = Array.from(cell.childNodes).filter(
+      (n) => n !== removeBar && !(n instanceof HTMLElement && n.classList.contains('cell-permalink'))
+    );
+    for (const child of children) {
+      wrapper.appendChild(child);
+    }
+    cell.insertBefore(wrapper, cell.firstChild);
+  }
+
+  /**
+   * Unwrap cell content: move children out of .cell-content-wrap back
+   * into the cell directly, then remove the wrapper.
+   */
+  function unwrapCellContent(cell: HTMLTableCellElement) {
+    const wrapper = cell.querySelector('.cell-content-wrap');
+    if (!wrapper) return;
+    while (wrapper.firstChild) {
+      cell.insertBefore(wrapper.firstChild, wrapper);
+    }
+    wrapper.remove();
+  }
+
+  /**
+   * Apply the full cross-highlight for the currently selected cell.
+   * Reads selectedCellInfo and applies column-hover, row-highlight,
+   * cross-active, hash-highlight, hash-row, and the in-flow remove bar.
+   */
+  function applySelectedHighlight(table: HTMLTableElement) {
+    if (!selectedCellInfo) return;
+
+    const { agentId, feature, colIndex } = selectedCellInfo;
+    const targetCell = table.querySelector(
+      `td[data-agent-id="${CSS.escape(agentId)}"][data-feature="${CSS.escape(feature)}"]`
+    ) as HTMLTableCellElement | null;
+    if (!targetCell) return;
+
+    const row = targetCell.closest('tr') as HTMLTableRowElement | null;
+    if (!row) return;
+
+    // Cross-active dimming
+    table.classList.add('cross-active');
+
+    // Column highlight
+    const allRows = table.querySelectorAll('tr');
+    allRows.forEach((r) => {
+      const cell = (r as HTMLTableRowElement).cells[colIndex];
+      if (cell) cell.classList.add('column-hover');
+    });
+
+    // Smart row highlight
+    const hoveredStatus = getCellStatusStatic(targetCell);
+    if (hoveredStatus) {
+      const featureCell = row.cells[0];
+      if (featureCell) featureCell.classList.add('row-highlight');
+      for (let i = 1; i < row.cells.length; i++) {
+        const sibling = row.cells[i];
+        const siblingStatus = getCellStatusStatic(sibling);
+        if (siblingStatus && statusMatchesThresholdStatic(siblingStatus, hoveredStatus)) {
+          sibling.classList.add('row-highlight');
+        }
+      }
+    }
+
+    // Hash-specific classes
+    targetCell.classList.add('hash-highlight');
+    row.classList.add('hash-row');
+
+    // Switch cell to flex-column layout and append the in-flow remove bar
+    wrapCellContent(targetCell);
+    targetCell.classList.add('has-selection');
+    targetCell.appendChild(removeBar);
+  }
+
+  /**
+   * Temporarily remove hash-highlight visual classes without clearing selectedCellInfo.
+   * Called when the hover system takes over (user hovers another cell).
+   * The remove bar stays in the selected cell — it is only removed on full dismiss.
+   */
+  function clearSelectedHighlight(table: HTMLTableElement) {
+    table.querySelectorAll('.hash-highlight').forEach((el) => el.classList.remove('hash-highlight'));
+    table.querySelectorAll('.hash-row').forEach((el) => el.classList.remove('hash-row'));
+  }
+
+  /**
+   * Fully dismiss the selection: clear selectedCellInfo, remove all highlight
+   * classes, restore the cell DOM, and clean the URL hash.
+   */
+  function dismissSelection(table: HTMLTableElement) {
+    // Restore the selected cell's DOM before clearing state
+    const prevCell = table.querySelector('td.has-selection') as HTMLTableCellElement | null;
+    if (prevCell) {
+      removeBar.remove();
+      prevCell.classList.remove('has-selection');
+      unwrapCellContent(prevCell);
+    }
+
+    selectedCellInfo = null;
+    table.querySelectorAll('.column-hover').forEach((el) => el.classList.remove('column-hover'));
+    table.querySelectorAll('.row-highlight').forEach((el) => el.classList.remove('row-highlight'));
+    table.querySelectorAll('.hash-highlight').forEach((el) => el.classList.remove('hash-highlight'));
+    table.querySelectorAll('.hash-row').forEach((el) => el.classList.remove('hash-row'));
+    table.classList.remove('cross-active');
+    history.replaceState(null, '', location.pathname + location.search);
+  }
+  // </DOCUMENTATION-SKILL:cell-permalink>
+
+  // <DOCUMENTATION-SKILL:table-hover>
+  function initTableHover() {
+    const table = document.querySelector('.table-card table');
+    if (!table) return;
+
+    let currentCol = -1;
+    let currentRow: HTMLTableRowElement | null = null;
+
+    function getCellStatus(cell: HTMLTableCellElement): string | null {
+      const badge = cell.querySelector('.badge');
+      if (badge) {
+        if (badge.classList.contains('supported')) return 'supported';
+        if (badge.classList.contains('partially-supported')) return 'partially-supported';
+        if (badge.classList.contains('not-supported')) return 'not-supported';
+        if (badge.classList.contains('not-verified')) return 'not-verified';
+      }
+      // Subscription cells with links count as supported
+      if (cell.querySelector('.links-list')) return 'supported';
+      return null;
+    }
+
+    function statusMatchesThreshold(cellStatus: string | null, hoveredStatus: string): boolean {
+      if (!cellStatus) return false;
+      if (hoveredStatus === 'supported') {
+        return cellStatus === 'supported';
+      }
+      // For not-supported, not-verified, partially-supported: highlight partial + supported
+      return cellStatus === 'supported' || cellStatus === 'partially-supported';
+    }
+
+    function clearColumnHover() {
+      const hovered = table!.querySelectorAll('.column-hover');
+      hovered.forEach((el) => el.classList.remove('column-hover'));
+      currentCol = -1;
+    }
+
+    function clearRowHighlight() {
+      const highlighted = table!.querySelectorAll('.row-highlight');
+      highlighted.forEach((el) => el.classList.remove('row-highlight'));
+      currentRow = null;
+    }
+
+    function applyColumnHover(colIndex: number) {
+      if (colIndex === currentCol) return;
+      clearColumnHover();
+      if (colIndex <= 0) return;
+      currentCol = colIndex;
+
+      const rows = table!.querySelectorAll('tr');
+      rows.forEach((row) => {
+        const cell = row.cells[colIndex];
+        if (cell) cell.classList.add('column-hover');
+      });
+    }
+
+    function applyRowHighlight(td: HTMLTableCellElement, row: HTMLTableRowElement) {
+      if (row === currentRow) return;
+      clearRowHighlight();
+      currentRow = row;
+
+      const hoveredStatus = getCellStatus(td);
+      if (!hoveredStatus) return;
+
+      // Always highlight the feature-name cell (column 0)
+      const featureCell = row.cells[0];
+      if (featureCell) featureCell.classList.add('row-highlight');
+
+      // Check each sibling agent cell
+      for (let i = 1; i < row.cells.length; i++) {
+        const sibling = row.cells[i];
+        const siblingStatus = getCellStatus(sibling);
+        if (statusMatchesThreshold(siblingStatus, hoveredStatus)) {
+          sibling.classList.add('row-highlight');
+        }
+      }
+    }
+
+    table.addEventListener('mouseover', (e) => {
+      const cell = (e.target as HTMLElement).closest('td, th') as HTMLTableCellElement | null;
+      if (!cell) return;
+
+      // When a selection is active, temporarily clear its visual classes
+      // so the hover system can highlight the currently hovered cell instead.
+      if (selectedCellInfo) {
+        clearSelectedHighlight(table as HTMLTableElement);
+      }
+
+      const colIndex = cell.cellIndex;
+      applyColumnHover(colIndex);
+
+      // Toggle cross-active dim effect when hovering agent columns
+      if (colIndex > 0) {
+        table!.classList.add('cross-active');
+      } else {
+        table!.classList.remove('cross-active');
+      }
+
+      // Row highlight only for body cells in agent columns
+      const row = cell.closest('tbody tr') as HTMLTableRowElement | null;
+      if (row && colIndex > 0) {
+        applyRowHighlight(cell, row);
+      } else {
+        clearRowHighlight();
+      }
+    });
+
+    table.addEventListener('mouseleave', () => {
+      clearColumnHover();
+      clearRowHighlight();
+      table!.classList.remove('cross-active');
+
+      // When the mouse leaves the table, re-apply the selected cell highlight
+      if (selectedCellInfo) {
+        applySelectedHighlight(table as HTMLTableElement);
+      }
+    });
+  }
+
+  document.addEventListener('astro:page-load', initTableHover);
+  initTableHover();
+  // </DOCUMENTATION-SKILL:table-hover>
+
+  // <DOCUMENTATION-SKILL:cell-permalink>
+  /**
+   * Cell permalink button ("#"), persistent selection, and hash-based highlight restore.
+   *
+   * - On hover over an agent cell, shows a small "#" button in the top-right corner.
+   * - Clicking it copies a stable URL (with hash) to the clipboard.
+   * - When the page loads with a hash like #claude-code!planmode/dual-mode,
+   *   the table applies a persistent cross-highlight on that cell.
+   * - The highlight persists until the user clicks "× Remove highlight" in the cell,
+   *   or is temporarily replaced when hovering another cell.
+   */
+  function initCellPermalink() {
+    const table = document.querySelector('.table-card table') as HTMLTableElement | null;
+    if (!table) return;
+
+    // --- Shared permalink button + tooltip elements (reused across cells) ---
+    const permalinkBtn = document.createElement('button');
+    permalinkBtn.className = 'cell-permalink';
+    permalinkBtn.textContent = '#';
+    permalinkBtn.setAttribute('aria-label', 'Copy link to this cell');
+
+    const tooltip = document.createElement('span');
+    tooltip.className = 'cell-permalink-tooltip';
+    tooltip.textContent = 'Copied to clipboard';
+    permalinkBtn.appendChild(tooltip);
+
+    let currentPermalinkCell: HTMLTableCellElement | null = null;
+    let copiedTimeout: ReturnType<typeof setTimeout> | null = null;
+
+    function showPermalink(cell: HTMLTableCellElement) {
+      if (cell === currentPermalinkCell) return;
+      // Only show on agent body cells (those with data-agent-id and data-feature)
+      if (!cell.dataset.agentId || !cell.dataset.feature) return;
+
+      currentPermalinkCell = cell;
+      // Reset visual state
+      permalinkBtn.classList.remove('copied');
+      tooltip.classList.remove('visible');
+      cell.appendChild(permalinkBtn);
+    }
+
+    function hidePermalink() {
+      if (currentPermalinkCell) {
+        permalinkBtn.remove();
+        currentPermalinkCell = null;
+      }
+    }
+
+    // Attach to table mouseover for showing the button
+    table.addEventListener('mouseover', (e) => {
+      const cell = (e.target as HTMLElement).closest('td[data-agent-id]') as HTMLTableCellElement | null;
+      if (cell) {
+        showPermalink(cell);
+      }
+    });
+
+    table.addEventListener('mouseleave', () => {
+      hidePermalink();
+    });
+
+    // Click handler for the permalink button
+    permalinkBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      e.preventDefault();
+
+      if (!currentPermalinkCell) return;
+      const agentId = currentPermalinkCell.dataset.agentId;
+      const feature = currentPermalinkCell.dataset.feature;
+      if (!agentId || !feature) return;
+
+      const hash = `#${agentId}!${feature}`;
+      const url = `${location.origin}${location.pathname}${hash}`;
+
+      // Activate persistent selection on the clicked cell
+      const colIndex = currentPermalinkCell.cellIndex;
+      if (colIndex > 0) {
+        // Dismiss any previous selection first
+        if (selectedCellInfo) {
+          dismissSelection(table);
+        }
+        selectedCellInfo = { agentId, feature, colIndex };
+        // Wrap content and add the remove bar now; the full cross-highlight
+        // will apply once the user moves away from the table (mouseleave).
+        wrapCellContent(currentPermalinkCell);
+        currentPermalinkCell.classList.add('has-selection');
+        currentPermalinkCell.appendChild(removeBar);
+      }
+
+      navigator.clipboard.writeText(url).then(() => {
+        // Visual feedback on button
+        permalinkBtn.classList.add('copied');
+
+        // Show tooltip
+        tooltip.classList.add('visible');
+
+        if (copiedTimeout) clearTimeout(copiedTimeout);
+        copiedTimeout = setTimeout(() => {
+          permalinkBtn.classList.remove('copied');
+          tooltip.classList.remove('visible');
+        }, 1500);
+      });
+    });
+
+    // Click handler for the "× Remove highlight" bar
+    removeBar.addEventListener('click', (e) => {
+      e.stopPropagation();
+      e.preventDefault();
+      dismissSelection(table);
+    });
+
+    // --- Hash-based highlight restore on page load ---
+    restoreHashHighlight(table);
+  }
+
+  function restoreHashHighlight(table: HTMLTableElement) {
+    const hash = location.hash;
+    if (!hash) return;
+
+    // Parse hash: #agentId!featureSlug or #agentId!featureSlug/subfeatureSlug
+    const match = hash.slice(1).match(/^([^!]+)!(.+)$/);
+    if (!match) return;
+
+    const [, agentId, feature] = match;
+
+    // Find the target cell by data attributes to validate the hash
+    const targetCell = table.querySelector(
+      `td[data-agent-id="${CSS.escape(agentId)}"][data-feature="${CSS.escape(feature)}"]`
+    ) as HTMLTableCellElement | null;
+    if (!targetCell) return;
+
+    const row = targetCell.closest('tr') as HTMLTableRowElement | null;
+    if (!row) return;
+
+    const colIndex = targetCell.cellIndex;
+    if (colIndex <= 0) return;
+
+    // Store the selection and apply the persistent highlight
+    selectedCellInfo = { agentId, feature, colIndex };
+    applySelectedHighlight(table);
+
+    // Scroll the target cell into view
+    targetCell.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+  }
+
+  document.addEventListener('astro:page-load', initCellPermalink);
+  initCellPermalink();
+  // </DOCUMENTATION-SKILL:cell-permalink>
+</script>


### PR DESCRIPTION
- Column highlight, smart row highlight, cross dimming, badge contrast mode
- Cell permalink button (#) copies stable URL to clipboard
- Clicking # activates persistent cell selection with full cross-highlight
- Hash-based highlight restore on page load with smooth scroll
- In-flow 'Remove highlight' bar at bottom of selected cell to dismiss
- Selection survives hover (temporarily replaced, re-applied on mouseleave)
- Documentation skills for table-hover and cell-permalink systems

<img width="1411" height="886" alt="image" src="https://github.com/user-attachments/assets/386d0a32-79b9-46c5-ac8c-42054b7c04cf" />

closes #24 